### PR TITLE
STEP14: Caching Strategy 적용 및 테스트 진행

### DIFF
--- a/src/main/java/com/hhplus/ecommerce/config/RedisConfig.java
+++ b/src/main/java/com/hhplus/ecommerce/config/RedisConfig.java
@@ -1,0 +1,72 @@
+package com.hhplus.ecommerce.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper){
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)));
+
+        Map<String, RedisCacheConfiguration> redisCacheConfigurationMap = new HashMap<>();
+        redisCacheConfigurationMap.put("topItems", redisCacheConfiguration.entryTtl(Duration.ofDays(1)));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .withInitialCacheConfigurations(redisCacheConfigurationMap)
+                .build();
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
         format_sql: true
         show_sql: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 # swagger
 springdoc:
   api-docs:

--- a/src/test/java/com/hhplus/ecommerce/application/cache/ItemServiceCacheTest.java
+++ b/src/test/java/com/hhplus/ecommerce/application/cache/ItemServiceCacheTest.java
@@ -1,0 +1,143 @@
+package com.hhplus.ecommerce.application.cache;
+
+import com.hhplus.ecommerce.application.ItemService;
+import com.hhplus.ecommerce.domain.Item;
+import com.hhplus.ecommerce.domain.repository.ItemRepository;
+import com.hhplus.ecommerce.domain.repository.OrderDetailRepository;
+import com.hhplus.ecommerce.domain.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@EnableCaching
+public class ItemServiceCacheTest {
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderDetailRepository orderDetailRepository;
+
+    @MockBean
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.getCache("allItems").clear();
+        cacheManager.getCache("topItems").clear();
+    }
+
+    @Test
+    @DisplayName("인기상품조회에서 2번째 조회할때 캐쉬를 사용하는지 확인")
+    void getTopItemWithCache() {
+        //given
+        LocalDateTime endDateTime = LocalDate.now().atStartOfDay();
+        LocalDateTime startDateTime = endDateTime.minusDays(3);
+        Item item1 = new Item("청바지1", 10000, 4, LocalDateTime.now());
+        Item item2 = new Item("청바지2", 20000, 5, LocalDateTime.now());
+        Item item3 = new Item("청바지3", 30000, 6, LocalDateTime.now());
+        List<Item> topItemList = new ArrayList<>();
+        topItemList.add(item1);
+        topItemList.add(item2);
+        topItemList.add(item3);
+        when(itemRepository.findTopItems(startDateTime, endDateTime)).thenReturn(topItemList);
+
+        //when1
+        List<Item> getTopItemsFirstTime = itemService.getTopItems();
+        //then1
+        assertThat(getTopItemsFirstTime).isNotNull();
+        assertThat(getTopItemsFirstTime).isEqualTo(topItemList);
+        verify(itemRepository, times(1)).findTopItems(startDateTime, endDateTime);
+
+        //when2
+        List<Item> getTopItemsSecondTime = itemService.getTopItems();
+        assertThat(getTopItemsSecondTime).isNotNull();
+//        assertThat(getTopItemsSecondTime).isEqualTo(topItemList);
+        verify(itemRepository, times(1)).findTopItems(startDateTime, endDateTime);
+    }
+
+    @Test
+    @DisplayName("인기상품조회에서 하루가 지나서 조회했을때 캐시를 조회해서 가져오는지 확인")
+    void getTopItemWithCacheAfter1Day() {
+        //given
+        LocalDateTime endDateTime = LocalDate.now().atStartOfDay();
+        LocalDateTime startDateTime = endDateTime.minusDays(3);
+        Item item1 = new Item("청바지1", 10000, 4, LocalDateTime.now());
+        Item item2 = new Item("청바지2", 20000, 5, LocalDateTime.now());
+        Item item3 = new Item("청바지3", 30000, 6, LocalDateTime.now());
+        List<Item> topItemList = new ArrayList<>();
+        topItemList.add(item1);
+        topItemList.add(item2);
+        topItemList.add(item3);
+        when(itemRepository.findTopItems(startDateTime, endDateTime)).thenReturn(topItemList);
+
+        //when1
+        List<Item> getTopItemsFirstTime = itemService.getTopItems();
+        //then1
+        assertThat(getTopItemsFirstTime).isNotNull();
+        assertThat(getTopItemsFirstTime).isEqualTo(topItemList);
+        verify(itemRepository, times(1)).findTopItems(startDateTime, endDateTime);
+
+        Clock clock = Clock.fixed(Instant.parse("2024-11-09T00:00:00.00Z"), ZoneId.systemDefault());
+        clock = Clock.offset(clock, Duration.ofDays(1));
+        LocalDateTime now = LocalDateTime.now(clock);
+        System.out.println("하루 경과 : " + now);
+
+        //when2
+        List<Item> getTopItemsSecondTime = itemService.getTopItems();
+        assertThat(getTopItemsSecondTime).isNotNull();
+        verify(itemRepository, times(1)).findTopItems(startDateTime, endDateTime);
+    }
+
+    @Test
+    @DisplayName("전체상품조회에서 2번째 조회할때 캐쉬를 사용하는지 확인")
+    void getAllItemWithCache() {
+        //given
+        LocalDateTime endDateTime = LocalDate.now().atStartOfDay();
+        LocalDateTime startDateTime = endDateTime.minusDays(3);
+        Item item1 = new Item("청바지1", 10000, 4, LocalDateTime.now());
+        Item item2 = new Item("청바지2", 20000, 5, LocalDateTime.now());
+        Item item3 = new Item("청바지3", 30000, 6, LocalDateTime.now());
+        List<Item> topItemList = new ArrayList<>();
+        topItemList.add(item1);
+        topItemList.add(item2);
+        topItemList.add(item3);
+        when(itemRepository.findAll()).thenReturn(topItemList);
+
+        //when1
+        List<Item> getAllItemsFirstTime = itemService.getItemAll();
+        //then1
+        assertThat(getAllItemsFirstTime).isNotNull();
+        assertThat(getAllItemsFirstTime).isEqualTo(topItemList);
+        verify(itemRepository, times(1)).findAll();
+
+        //when2
+        List<Item> getAllItemsSecondTime = itemService.getTopItems();
+        assertThat(getAllItemsSecondTime).isNotNull();
+        verify(itemRepository, times(1)).findAll();
+    }
+
+}


### PR DESCRIPTION
### STEP 13_기본
- [X] 조회가 오래 걸리는 쿼리에 대한 캐싱, 혹은 Redis 를 이용한 로직 이관을 통해 성능 개선할 수 있는 로직을 분석하고 이를 합리적인 이유와 함께 정리한 문서 제출
    - [README.md](https://github.com/taek00n/hhplus-e-commerce/blob/STEP13/README.md)

### STEP 14_심화
- [X] Caching을 활용하여 부하를 최소화할 수 있는 비즈니스 로직을 파악해보고, 적절한 Caching Strategy를 적용하는 코드 작성
    - [인기상품조회에 Refresh-Ahead 적용](https://github.com/taek00n/hhplus-e-commerce/blob/2cba0f6f0d59bbaa1ef0ec22bf640cc8db3f7842/src/main/java/com/hhplus/ecommerce/application/ItemService.java#L56-L71)
    - [전체상품조회에 Cache-Aside 적용](https://github.com/taek00n/hhplus-e-commerce/blob/2cba0f6f0d59bbaa1ef0ec22bf640cc8db3f7842/src/main/java/com/hhplus/ecommerce/application/ItemService.java#L36)

- [X] Caching을 활용하여 부하를 최소화할 수 있는 비즈니스 로직을 파악해보고, 적절한 Caching Strategy를 적용하는 코드 테스트 작성
    - [인기상품조회 2번 조회](https://github.com/taek00n/hhplus-e-commerce/blob/2cba0f6f0d59bbaa1ef0ec22bf640cc8db3f7842/src/test/java/com/hhplus/ecommerce/application/cache/ItemServiceCacheTest.java#L53)
    - [인기상품조회 하루 뒤 조회](https://github.com/taek00n/hhplus-e-commerce/blob/2cba0f6f0d59bbaa1ef0ec22bf640cc8db3f7842/src/test/java/com/hhplus/ecommerce/application/cache/ItemServiceCacheTest.java#L82)
    - [전체상품조회 2번 조회](https://github.com/taek00n/hhplus-e-commerce/blob/2cba0f6f0d59bbaa1ef0ec22bf640cc8db3f7842/src/test/java/com/hhplus/ecommerce/application/cache/ItemServiceCacheTest.java#L115)
---

✅  적용 사항
인기 상품 조회에는 Refresh-Ahead를 적용하였습니다.
처음 Cache에 넣어주고 매일 12시마다 Scheduled이 돌면서 3일 이전의 인기 상품을 Cache에 넣어줍니다.

 상품조회에는 Cache-Aside를 적용하였습니다.